### PR TITLE
Log: Improve logging

### DIFF
--- a/src/common/inc/log.h
+++ b/src/common/inc/log.h
@@ -17,14 +17,37 @@ namespace {
     };
 }
 
+std::string getColor(LogLevel level) {
+    switch(level) {
+    case DEBUG:
+        return "\033[0;90m";
+    case INFO:
+        return "\033[0;37m";
+    case NOTICE:
+        return "\033[0;36m";
+    case WARNING:
+        return "\033[0;33m";
+    case ERROR:
+        return "\033[0;91m";
+    case CRITICAL:
+        return "\033[0;31m";
+    case ALERT:
+        return "\033[0;101m";
+    case FATAL:
+        return "\033[0;41m";
+    default:
+        return "\033[0m";
+    }
+}
+
 class JournalLog {
 public:
     JournalLog(std::string &name, LogLevel level) {
-        operator << ((level == NONE ? "" : "<"+std::to_string(level)+"> ") +
+        operator << (getColor(level) + (level == NONE ? "" : "<"+std::to_string(level)+"> ") +
                     (name.empty() ? "" : "["+name+"] "));
     }
     ~JournalLog() {
-        std::cout << std::endl;
+        std::cout << getColor(NONE) << std::endl;
     }
     template<class T>
     JournalLog &operator<<(const T &msg) {

--- a/src/dbus/src/dbus.cpp
+++ b/src/dbus/src/dbus.cpp
@@ -2,7 +2,7 @@
 #include "settingReaderFactory.h"
 
 dbusGet_t DBusGeshSetting::Get(const std::vector<std::string>& keys) {
-    log.info() << "Get called";
+    log.info() << "Get called, " << keys.size() << " settings requested";
 
     dbusGet_t ret;
     for (auto key: keys) {
@@ -10,6 +10,7 @@ dbusGet_t DBusGeshSetting::Get(const std::vector<std::string>& keys) {
             auto setting = m_handler->Get(key, m_iface);
             std::get<0>(ret)[key] = sdbus::Variant(ToSdBusVariant(setting));
         } catch ( SettingException const & ex ) {
+            log.warning() << "Failed to get: " << key << ", " << ex.what();
             std::get<1>(ret)[key] = ex.who();
         }
     }
@@ -31,7 +32,7 @@ std::tuple<std::map<std::string, sdbus::Variant>, std::vector<std::string>> DBus
 }
 
 void DBusGeshSetting::Set(const std::map<std::string, sdbus::Variant>& update, const std::vector<std::string>& invalidate) {
-    log.info() << "Set called";
+    log.notice() << "Set called";
 
     std::map<std::string, setting_t> in;
     for (auto const& [key, val] : update) {
@@ -45,6 +46,7 @@ void DBusGeshSetting::Set(const std::map<std::string, sdbus::Variant>& update, c
     try {
         m_handler->Set(in, m_iface);
     } catch ( SettingException const & ex ) {
+        log.warning() << "Set failed: " << ex.what();
         throw sdbus::Error("own.gesh.Error", ex.what());
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,17 +74,17 @@ int main(int argc, char *argv[])
     auto srf = SettingReaderFactory(searchPaths, setting_logger);
     auto readers = srf.getReaders();
 
-    log.debug() << "Initializing settings... ";
+    log.info() << "Initializing settings... ";
     auto handler = SettingHandler(init, readers, setting_logger);
-    log.debug() << "Setting initialization DONE. ";
+    log.notice() << "Setting initialization DONE. ";
     for ( auto const& [key, val] : handler.GetAll(nullptr) ) {
-        log.debug() << "    " << val;
+        log.info() << "    " << val;
     }
 
     auto connection = sdbus::createSessionBusConnection();
     connection->requestName(DBUS_SERVICE);
     connection->enterEventLoopAsync();
-    log.debug() << "D-Bus service name aquired. ";
+    log.notice() << "D-Bus service name aquired. ";
 
     auto manager = std::make_unique<ManagerAdaptor>(*connection, "/");
     std::vector<std::shared_ptr<DBusGeshSetting>> dbus_settings;
@@ -98,7 +98,7 @@ int main(int argc, char *argv[])
         iface->RegisterManager(manager);
         dbus_settings.push_back(manager);
     }
-    log.debug() << "D-Bus objects registered. ";
+    log.notice() << "D-Bus objects registered. ";
 
     while (true) {
         std::this_thread::sleep_for(std::chrono::seconds(1));

--- a/src/setting/inc/setting.h
+++ b/src/setting/inc/setting.h
@@ -43,6 +43,7 @@ private:
     ISettingRule *m_rule;
     std::vector<SettingInterface*> m_readers;
     std::vector<SettingInterface*> m_writers;
+    Log log;
 };
 
 class SettingHandler {

--- a/src/setting/inc/settingTypes.h
+++ b/src/setting/inc/settingTypes.h
@@ -6,15 +6,10 @@
 #include <variant>
 #include <string>
 
-#include "log.h"
-
 using setting_t = std::variant<std::monostate, bool, int, std::string>;
 
 struct SettingException : public std::exception {
-    SettingException(const std::string &msg, const std::string child = "") : m_exc("setting" + child), m_msg(m_exc + ": " + msg) {
-        auto log = Log("setting.exception");
-        log.warning() << m_exc << ": " << msg;
-    }
+    SettingException(const std::string &msg, const std::string child = "") : m_exc("setting" + child), m_msg(m_exc + ": " + msg) {}
     virtual const char* what() const throw()
     {
       return m_msg.c_str();


### PR DESCRIPTION
* Use more of the available log levels
* Add colors to the output
  - This makes it easier to visually determine if an entry is important.
* Remove logging in SettingsException class
  - While having the error be printed as part of throwing the error made some sense, the log entry itself didn't help in understanding what was going on then the excepion was thrown.
  - Log entries are now made where the exception is caught (if relevant), providing more context to the log entry.